### PR TITLE
fix command null error

### DIFF
--- a/cronjob/templates/cronjob.yaml
+++ b/cronjob/templates/cronjob.yaml
@@ -24,7 +24,9 @@ spec:
             -
               name: app
               image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+              {{- if .Values.command }}
               command: {{- toYaml .Values.command | nindent 14 }}
+              {{- end }}
               {{- if hasKey .Values "resources" }}
               resources: {{ toYaml .Values.resources | nindent 14 }}
               {{- end }}


### PR DESCRIPTION
`helm install ~/github/helm-charts/cronjob --name grafana-backup --namespace grafana -f helm/grafana-backup.yaml --dry-run --debug`

```
Error: YAML parse error on cronjob/templates/cronjob.yaml: error converting YAML to JSON: yaml: line 28: could not find expected ':'
```
