### PR TITLE
update fluentd apiVersion for k8s 1.16

### DIFF
--- a/fluentd-cloudwatch/templates/daemonset.yaml
+++ b/fluentd-cloudwatch/templates/daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd-cloudwatch
@@ -6,6 +6,9 @@ metadata:
   labels:
     k8s-app: fluentd-cloudwatch
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-cloudwatch
   template:
     metadata:
       labels:


### PR DESCRIPTION
ec-eks-staging k8s版本為1.16
daemonSet apiVersion已經修改為 apps/v1
ref1: https://cloud.google.com/kubernetes-engine/docs/release-notes
ref2: https://github.com/kubernetes/kubernetes/issues/84782