### PR TITLE
service resource support setting label

### DIFF
--- a/simple/templates/service.yaml
+++ b/simple/templates/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   name: {{ .Values.name }}
   annotations: {{ toYaml .Values.service.annotations | nindent 4 }}
+  labels: {{ toYaml .Values.service.labels | nindent 4 }}
 spec:
   ports:
 {{- range .Values.service.ports }}


### PR DESCRIPTION
for prometheus-operater setting, that need label to get service monitor endpoint