### PR TITLE
fix(cronjob) secretKeyRef name and key

### DIFF
--- a/cronjob/templates/cronjob.yaml
+++ b/cronjob/templates/cronjob.yaml
@@ -38,12 +38,12 @@ spec:
                 - name: {{ $key }}
                   value: {{ $value | quote }}
                 {{- end }}
-                {{- range $key, $name := .Values.envSecrets }}
+                {{- range $key, $ref := .Values.envSecrets }}
                 - name: {{ $key }}
                   valueFrom:
                     secretKeyRef:
-                      name: {{ $name }}
-                      key: {{ $key | quote }}
+                      name: {{ $ref.name }}
+                      key: {{ $ref.key | quote }}
                 {{- end }}
               {{- if .Values.envFrom }}
               envFrom:


### PR DESCRIPTION
fix the following error
>  a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')