### PR TITLE
deployment default prefer difference AZ/Node

### DIFF
--- a/cronjob/templates/cronjob.yaml
+++ b/cronjob/templates/cronjob.yaml
@@ -8,6 +8,9 @@ spec:
   successfulJobsHistoryLimit: {{ .Values.job.history.success | default 3 }}
   failedJobsHistoryLimit: {{ .Values.job.history.failed | default 1 }}
   concurrencyPolicy: {{ .Values.job.concurrency | default "Allow" }}
+  {{- if .Values.startingDeadlineSeconds }}
+  startingDeadlineSeconds: {{ .Values.startingDeadlineSeconds }}
+  {{- end }}
   jobTemplate:
     metadata:
       annotations:

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -1,5 +1,7 @@
 schedule: "0 * * * *"
 
+startingDeadlineSeconds: {}
+
 job:
   retries: 1
   timeout: 1800

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.0.2
+version: 0.0.3
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -34,10 +34,39 @@ spec:
       nodeSelector:
         {{ .Values.nodeSelector.labelName }}: {{ .Values.nodeSelector.labelValue }} 
       {{- end}}
-      {{- if hasKey .Values.deployment "affinity" }}
       affinity:
-        {{- toYaml .Values.deployment.affinity | nindent 8 }}
-      {{- end}}
+        {{- if hasKey .Values.affinity "nodeAffinity" }}
+        nodeAffinity: {{- toYaml .Values.affinity.nodeAffinity | nindent 10 }}
+        {{- end }}
+        {{- if hasKey .Values.affinity "podAffinity" }}
+        podAffinity: {{- toYaml .Values.affinity.podAffinity | nindent 10 }}
+        {{- end }}
+        podAntiAffinity:
+          {{- if hasKey .Values.affinity.podAntiAffinity "requiredDuringSchedulingIgnoredDuringExecution" }}
+          requiredDuringSchedulingIgnoredDuringExecution: {{- toYaml .Values.affinity.podAntiAffinity.requiredDuringSchedulingIgnoredDuringExecution | nindent 12 }}
+          {{- end }}
+          preferredDuringSchedulingIgnoredDuringExecution:
+          {{- if hasKey .Values.affinity.podAntiAffinity "preferredDuringSchedulingIgnoredDuringExecution" }}
+            {{- toYaml .Values.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution | nindent 12 }}
+          {{- end }}
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - {{ .Values.name }}
+                topologyKey: failure-domain.beta.kubernetes.io/zone
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - {{ .Values.name }}
+                topologyKey: kubernetes.io/hostname
+              weight: 99
       {{- if hasKey .Values "securityContextForPod" }}
       securityContext: 
         {{ toYaml .Values.securityContextForPod | nindent 8 }}        

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -19,6 +19,13 @@ replicaCount: 1
 #   runAsGroup: 1000
 #   fsGroup: 1000
 
+affinity:
+  nodeAffinity: {}
+  podAffinity: {}
+  # if you set .podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution,you will combined with default setting.
+  # default: prefer difference az(weight:100) and node(weight:99)
+  podAntiAffinity: {}
+
 deployment: {}
 # deployment example
 # deployment: 


### PR DESCRIPTION
helm diff shop-nc in ec-eks-db-preview result:
```
+       affinity:
+         nodeAffinity:
+           {}
+
+         podAffinity:
+           {}
+
+         podAntiAffinity:
+           preferredDuringSchedulingIgnoredDuringExecution:
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - shop-nc
+                 topologyKey: failure-domain.beta.kubernetes.io/zone
+               weight: 100
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - shop-nc
+                 topologyKey: kubernetes.io/hostname
+               weight: 99
```