### PR TITLE
disable helm2 default allocate to difference az/node

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.0.3
+version: 0.1.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       nodeSelector:
         {{ .Values.nodeSelector.labelName }}: {{ .Values.nodeSelector.labelValue }} 
       {{- end}}
+      {{- if hasKey .Values "affinity" }}
       affinity:
         {{- if hasKey .Values.affinity "nodeAffinity" }}
         nodeAffinity: {{- toYaml .Values.affinity.nodeAffinity | nindent 10 }}
@@ -67,6 +68,7 @@ spec:
                     - {{ .Values.name }}
                 topologyKey: kubernetes.io/hostname
               weight: 99
+      {{- end }}
       {{- if hasKey .Values "securityContextForPod" }}
       securityContext: 
         {{ toYaml .Values.securityContextForPod | nindent 8 }}        


### PR DESCRIPTION
以下測試目的為這次更新後，所有更新場景皆可以不受影響．

測試一般deploy
helm2:
**helm diff upgrade shop-nc ~/github/helm-charts/simple --set-string deployment.containers.shop-nc.image.tag=616925d -f shop-nc.yaml -f cm-env.yaml -f secret-env.yaml**

```
+       affinity:
+         nodeAffinity:
+           {}
+
+         podAffinity:
+           {}
+
+         podAntiAffinity:
+           preferredDuringSchedulingIgnoredDuringExecution:
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - shop-nc
+                 topologyKey: failure-domain.beta.kubernetes.io/zone
+               weight: 100
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - shop-nc
+                 topologyKey: kubernetes.io/hostname
+               weight: 99
        containers:
        - name: shop-nc
-         image: "332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/shopline/shop:10c0e87"
+         image: "332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/shopline/shop:616925d"
```
helm3:

**helm3 diff -n ec-stg-41 upgrade admin ~/github/helm-charts/simple -f dist/admin.yaml -f dist/cm-share-env.yaml -f dist/secret-share-env.yaml --set-string deployment.containers.admin.image.tag=dc62c7c_staging**

```shell
+         podAffinity:
+           {}
+         podAntiAffinity:
+           preferredDuringSchedulingIgnoredDuringExecution:
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - admin
+                 topologyKey: failure-domain.beta.kubernetes.io/zone
+               weight: 100
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - admin
+                 topologyKey: kubernetes.io/hostname
+               weight: 99
```


測試reuse-values
helm2:

**helm diff upgrade shop-nc ~/github/helm-charts/simple --set-string deployment.containers.shop-nc.image.tag=616925d --reuse-values**

```shell
-         image: "332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/shopline/shop:10c0e87"
+         image: "332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/shopline/shop:616925d"
```
helm3:

**helm3 diff -n ec-stg-41 upgrade admin ~/github/helm-charts/simple --reuse-values --set-string deployment.containers.admin.image.tag=dc62c7c_staging**

```shell
      spec:
        affinity:
          nodeAffinity:
+           {}
+         podAffinity:
+           {}
+         podAntiAffinity:
            preferredDuringSchedulingIgnoredDuringExecution:
-           - preference:
-               matchExpressions:
-               - key: nodegroup
-                 operator: In
-                 values:
-                 - ec-eks-staging-spot-autoscaling-group
-             weight: 10
-           - preference:
-               matchExpressions:
-               - key: nodegroup
-                 operator: In
-                 values:
-                 - ec-eks-staging-memory-node-autoscaling-group
-             weight: 5
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - admin
+                 topologyKey: failure-domain.beta.kubernetes.io/zone
+               weight: 100
+             - podAffinityTerm:
+                 labelSelector:
+                   matchExpressions:
+                   - key: app
+                     operator: In
+                     values:
+                     - admin
+                 topologyKey: kubernetes.io/hostname
+               weight: 99
```