### PR TITLE
feat(terminationGrace):extend termination grace to 61

### DIFF
--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -108,4 +108,4 @@ spec:
           - name: ndots
             value: "2"
       {{- end }}
-      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds | default "30" }}
+      terminationGracePeriodSeconds: {{ .Values.deployment.terminationGracePeriodSeconds | default "61" }}


### PR DESCRIPTION
Extending termination seconds to 61 as this is slightly longer then our general application requests' timeout 