### PR TITLE
add service monitor template

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/servicemonitor.yaml
+++ b/simple/templates/servicemonitor.yaml
@@ -1,0 +1,29 @@
+{{- range $serviceMonitorName, $ref := .Values.serviceMonitors }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $serviceMonitorName }}
+  labels:
+    release: prometheus-operator
+  {{- if hasKey $ref "labels" }}
+    {{- range $key, $value := $ref.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+  namespace: prometheus-operator
+spec:
+  namespaceSelector:
+    matchNames:
+    {{- range $namespace := $ref.namespaceSelector }}
+      - {{ $namespace }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- range $key, $value := $ref.selector.matchLabels }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+  endpoints:
+  {{- range $ref.endpoints }}
+    - port: {{ .port | quote }}
+  {{- end }}
+{{- end}}

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -153,3 +153,13 @@ pdb:
 #        ...
 #        xcPaL4GCgUl+8TiK
 #        -----END CERTIFICATE-----
+
+# serviceMonitors:
+#   mongodb-observer:
+#     namespaceSelector:
+#       - shoplytics
+#     selector:
+#       matchLabels:
+#         app: mongodb-observer # which service you want to match
+#     endpoints:
+#       - port: http # port name of the service expose


### PR DESCRIPTION
Using helm to deploy service monitor resource for us would be nice!

The label has a default value `release: prometheus-operator` which can make the prometheus-operator pick up the service monitor.

Also, the service monitor should be put in `namespace: prometheus-operator` by default.

----------
Here is a nice article to introduce the prometheus / service monitor / service / pods

https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/troubleshooting.md#troubleshooting-servicemonitor-changes