### PR TITLE
fix chart oversize issue

### DIFF
--- a/cronjob/.helmignore
+++ b/cronjob/.helmignore
@@ -1,0 +1,4 @@
+.git
+.github
+*.md
+*.tgz

--- a/fluentd-cloudwatch/.helmignore
+++ b/fluentd-cloudwatch/.helmignore
@@ -1,0 +1,4 @@
+.git
+.github
+*.md
+*.tgz

--- a/simple/.helmignore
+++ b/simple/.helmignore
@@ -1,0 +1,4 @@
+.git
+.github
+*.md
+*.tgz


### PR DESCRIPTION
check re-package helm chart size:
before:(include *.tgz)
```shell
ls -al simple-0.4.0.tgz
-rw-r--r--   1 andychuang  staff  1014712 10 15 12:50 simple-0.4.0.tgz
tar -zxf simple-0.4.0.tgz
ls -al simple
drwxr-xr-x  11 andychuang  staff     352 10 15 12:42 .
drwxr-xr-x  13 andychuang  staff     416 10 15 12:42 ..
-rw-r--r--   1 andychuang  staff     125 10 14 12:05 Chart.yaml
-rw-r--r--   1 andychuang  staff   25631 10 14 12:05 simple-0.0.1.tgz
-rw-r--r--   1 andychuang  staff   31460 10 14 12:05 simple-0.0.2.tgz
-rw-r--r--   1 andychuang  staff   63285 10 14 12:05 simple-0.0.3.tgz
-rw-r--r--   1 andychuang  staff  126586 10 14 12:05 simple-0.1.0.tgz
-rw-r--r--   1 andychuang  staff  253347 10 14 12:05 simple-0.2.0.tgz
-rw-r--r--   1 andychuang  staff  507190 10 14 12:05 simple-0.3.0.tgz
drwxr-xr-x  19 andychuang  staff     608 10 15 12:42 templates
-rw-r--r--   1 andychuang  staff    4431 10 14 12:05 values.yaml
```

after:(exclude *.tgz)
```shell
ls -al simple-0.4.0.tgz
-rw-r--r--   1 andychuang  staff  5508 10 15 12:58 simple-0.4.0.tgz
ls -al simple
drwxr-xr-x   6 andychuang  staff   192 10 15 12:59 .
drwxr-xr-x   8 andychuang  staff   256 10 15 12:59 ..
-rw-r--r--   1 andychuang  staff    24 10 15 12:58 .helmignore
-rw-r--r--   1 andychuang  staff   125 10 15 12:58 Chart.yaml
drwxr-xr-x  19 andychuang  staff   608 10 15 12:59 templates
-rw-r--r--   1 andychuang  staff  4431 10 15 12:58 values.yaml
```