### PR TITLE
feat(backburner) support create many ruby backburner workers

### DIFF
--- a/.github/workflows/update-chart.yaml
+++ b/.github/workflows/update-chart.yaml
@@ -31,6 +31,7 @@ jobs:
           helm package simple -d simple
           helm package fluentd-cloudwatch -d fluentd-cloudwatch
           helm package cronjob -d cronjob
+          helm package backburner -d backburner
           helm repo index . --url https://shoplineapp.github.io/helm-charts
           ls -al simple/
           cat index.yaml

--- a/backburner/.helmignore
+++ b/backburner/.helmignore
@@ -1,0 +1,4 @@
+.git
+.github
+*.md
+*.tgz

--- a/backburner/Chart.yaml
+++ b/backburner/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: Helm chart for ruby backburner workers
+name: backburner
+version: 0.1.0
+appVersion: 0.0.1

--- a/backburner/templates/_container.tpl
+++ b/backburner/templates/_container.tpl
@@ -1,0 +1,60 @@
+{{- define "deployment.container" -}}
+        name: {{ .queue }}
+        {{- if hasKey . "command" }}
+        command: {{ toYaml .command | nindent 8 }}
+        {{- else }}
+        command:
+          - sh
+          - -c
+        {{- end }}
+        {{- if hasKey . "args" }}
+        args: {{ toYaml .args | nindent 8 }}
+        {{- else }}
+        args:
+          - bundle exec backburner -e $RAILS_ENV -q {{ .queue }}
+        {{- end }}
+        image: "{{ .image.repository }}:{{ .image.tag }}"
+        imagePullPolicy: "IfNotPresent"
+        env:
+        - name: CONTAINER_NAME
+          value: {{ .queue }}
+        {{- range $key, $value := .env }}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{- end }}
+        {{- range $key, $ref := .envSecrets }}
+        - name: {{ $key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $ref.name }}
+              key: {{ $ref.key | quote }}
+        {{- end }}
+        envFrom:
+        {{- range .envFromConfigmap }}
+        - configMapRef:
+            name: {{ .name }}
+        {{- end }}
+        {{- range .envFromSecret }}
+        - secretRef:
+            name: {{ .name }}
+        {{- end }}
+        {{- if hasKey . "resources" }}
+        resources: {{- toYaml .resources | nindent 10 }}
+        {{- else }}
+        resources:
+          limits:
+            cpu: "1"
+            memory: "1Gi"
+          requests:
+            cpu: "1"
+            memory: "1Gi"
+        {{- end }}
+        {{- if hasKey . "lifecycle" }}
+        lifecycle: {{- toYaml .lifecycle | nindent 10 }}
+        {{- else }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["sleep", "15"]
+        {{- end }}
+{{- end -}}

--- a/backburner/templates/_container.tpl
+++ b/backburner/templates/_container.tpl
@@ -1,5 +1,5 @@
 {{- define "deployment.container" -}}
-        name: {{ .queue }}
+        name: {{ .resourceName }}
         {{- if hasKey . "command" }}
         command: {{ toYaml .command | nindent 8 }}
         {{- else }}
@@ -17,7 +17,7 @@
         imagePullPolicy: "IfNotPresent"
         env:
         - name: CONTAINER_NAME
-          value: {{ .queue }}
+          value: {{ .resourceName }}
         {{- range $key, $value := .env }}
         - name: {{ $key }}
           value: {{ $value | quote }}

--- a/backburner/templates/deployment.yaml
+++ b/backburner/templates/deployment.yaml
@@ -1,12 +1,13 @@
 {{ range .Values.workers }}
-{{ $worker := merge . $.Values.global }}
+{{ $resourceName := (ternary .name .queue (not (empty .name))) }}
+{{ $worker := merge . $.Values.global (dict "resourceName" $resourceName) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Values.name }}-{{ .queue }}
+  name: {{ $.Values.name }}-{{ $resourceName }}
   namespace: {{ $.Release.Namespace }}
   labels:
-    app: {{ $.Values.name }}-{{ .queue }}
+    app: {{ $.Values.name }}-{{ $resourceName }}
 spec:
   strategy:
     rollingUpdate:
@@ -15,11 +16,11 @@ spec:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: {{ $.Values.name }}-{{ .queue }}
+      app: {{ $.Values.name }}-{{ $resourceName }}
   template:
     metadata:
       labels:
-        app: {{ $.Values.name }}-{{ .queue }}
+        app: {{ $.Values.name }}-{{ $resourceName }}
     spec:
       containers:
       - {{ template "deployment.container" $worker }}

--- a/backburner/templates/deployment.yaml
+++ b/backburner/templates/deployment.yaml
@@ -1,0 +1,36 @@
+{{ range .Values.workers }}
+{{ $worker := merge . $.Values.global }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $.Values.name }}-{{ .queue }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Values.name }}-{{ .queue }}
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ $.Values.name }}-{{ .queue }}
+  template:
+    metadata:
+      labels:
+        app: {{ $.Values.name }}-{{ .queue }}
+    spec:
+      containers:
+      - {{ template "deployment.container" $worker }}
+      restartPolicy: Always
+      {{- if $.Values.serviceaccount}}
+      serviceAccountName: {{ $.Values.name }}-pod-service-account
+      {{- end }}
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "2"
+      terminationGracePeriodSeconds: 61
+---
+{{- end }}

--- a/backburner/templates/hpa.yaml
+++ b/backburner/templates/hpa.yaml
@@ -1,0 +1,40 @@
+{{ range .Values.workers }}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ $.Values.name }}-{{ .queue }}
+spec:
+  {{- if .hpav2 }}
+  minReplicas: {{ .hpav2.minReplicas }}
+  maxReplicas: {{ .hpav2.maxReplicas }}
+  metrics:
+  {{- range .hpav2.Resource }}
+  - type: Resource
+    resource:
+      name: {{ .name }}
+      target:
+        {{- if .percent}}
+        type: Utilization
+        averageUtilization: {{ .percent }}
+        {{- else if .value}}
+        type: AverageValue
+        averageValue: {{ .value }}
+        {{- end }}
+  {{- end }}
+  {{- else }}
+  minReplicas: 1
+  maxReplicas: 1
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 70
+  {{- end }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ $.Values.name }}-{{ .queue }}
+---
+{{- end }}

--- a/backburner/templates/hpa.yaml
+++ b/backburner/templates/hpa.yaml
@@ -1,8 +1,10 @@
 {{ range .Values.workers }}
+{{- if ne "false" (.enableHPA | toString) }}
+{{- $resourceName := (ternary .name .queue (not (empty .name))) }}
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ $.Values.name }}-{{ .queue }}
+  name: {{ $.Values.name }}-{{ $resourceName }}
 spec:
   {{- if .hpav2 }}
   minReplicas: {{ .hpav2.minReplicas }}
@@ -35,6 +37,7 @@ spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ $.Values.name }}-{{ .queue }}
+    name: {{ $.Values.name }}-{{ $resourceName }}
 ---
+{{- end }}
 {{- end }}

--- a/backburner/templates/serviceaccount.yaml
+++ b/backburner/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceaccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {{ toYaml .Values.serviceaccount.annotations | nindent 4}}
+  name: {{ .Values.name }}-pod-service-account
+{{- end }}

--- a/backburner/values.yaml
+++ b/backburner/values.yaml
@@ -14,6 +14,7 @@ global:
 
 workers: []
 # - queue: custom-jobs
+#   name: custom-jobs
 #   resources:
 #     limits:
 #       cpu: "300m"
@@ -26,6 +27,7 @@ workers: []
 #     - -c
 #   args:
 #     - my custom command;
+#   enableHPA: true
 #   hpav2:
 #     minReplicas: 1
 #     maxReplicas: 1

--- a/backburner/values.yaml
+++ b/backburner/values.yaml
@@ -1,0 +1,34 @@
+name: backburner-name
+
+global:
+  image:
+    repository: repository_name/image
+    tag: tag
+  serviceaccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::*******:role/*********
+  envFromConfigmap:
+    - name: cm-env
+  envFromSecret:
+    - name: secret-env
+
+workers: []
+# - queue: custom-jobs
+#   resources:
+#     limits:
+#       cpu: "300m"
+#       memory: "500Mi"
+#     requests:
+#       cpu: "300m"
+#       memory: "500Mi"
+#   command:
+#     - sh
+#     - -c
+#   args:
+#     - my custom command;
+#   hpav2:
+#     minReplicas: 1
+#     maxReplicas: 1
+#     Resource:
+#       - name: cpu
+#         percent: 70


### PR DESCRIPTION
This chart will support create backburner workers more easier.  
For example, we can create our worker likes below:

```
name: our-service-worker

global:
  image:
    repository: *************/shopline/our-service
    tag: **********
  serviceaccount:
    annotations:
      eks.amazonaws.com/role-arn: ************/our-service-role
  envFromConfigmap:
    - name: our-service-env
  envFromSecret:
    - name: our-service-env

workers:
  - queue: our-service-worker-1
  - queue: our-service-worker-2
  - queue: our-service-worker-3
```