### PR TITLE
Feature/support keda scale object

### DIFF
--- a/example/example-keda.yaml
+++ b/example/example-keda.yaml
@@ -1,0 +1,51 @@
+name: example-keda
+
+deployment:
+  containers:
+    nginx:
+      name: nginx
+      image:
+        repository: nginx
+        tag: latest
+      resources:
+        requests:
+          memory: "64Mi"
+          cpu: "25m"
+        limits:
+          memory: "128Mi"
+          cpu: "50m"
+KEDA:
+  ScaledObject:
+    spec:
+      minReplicaCount: 0
+      maxReplicaCount: 10
+      triggers:
+      - type: cpu
+        metadata:
+          type: Utilization
+          value: "60"
+      - type: aws-cloudwatch
+        metadata:
+          namespace: AWS/EC2
+          dimensionName: InstanceId
+          dimensionValue: i-089078878e79b6104
+          metricName: CPUUtilization
+          targetMetricValue: "60"
+          minMetricValue: "0"
+          awsRegion: "ap-southeast-1"
+          identityOwner: operator
+          metricCollectionTime: "60"
+          metricStat: "Sum"
+          metricStatPeriod: "60"
+      - type: cron
+        metadata:
+          timezone: Asia/Taipei
+          start: 34 17 4 1 *
+          end: 50 17 4 1 *
+          desiredReplicas: "10"
+      - type: prometheus
+        metadata:
+          serverAddress: http://prometheus-operator-kube-p-prometheus.prometheus-operator:9090
+          metricName: machine_cpu_cores
+          threshold: '100'
+          query: sum(machine_cpu_cores)

--- a/simple/templates/scale_object.yaml
+++ b/simple/templates/scale_object.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.KEDA }}
+  {{- if (and .Values.KEDA.ScaledObject (or .Values.hpa .Values.hpav2)) }}
+    {{ fail "Don't create ScaledObject and HPA at same time." }}
+  {{- end }}
+  {{- if .Values.KEDA.ScaledObject }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+spec: {{ toYaml .Values.KEDA.ScaledObject.spec | nindent 2 }}
+  scaleTargetRef:
+    name: {{ .Values.name }}
+  {{- end }}
+{{- end }}
+
+# can remove when all extenral.metrics.aws migrate to KEDA.
+{{- if .Values.hpav2 }}
+  {{- if .Values.hpav2.External }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    name: {{ .Values.name }}
+  minReplicaCount: {{ .Values.hpav2.minReplicas }}
+  maxReplicaCount: {{ .Values.hpav2.maxReplicas }}
+  triggers:
+  {{- range .Values.hpav2.Resource }}
+  - type: {{ .name }}
+    metadata:
+      {{- if .percent }}
+      type: Utilization
+      value: {{ .percent | quote  }}
+      {{- else if .value}}
+      type: AverageValue
+      value: {{ .value | quote }}
+      {{- end }}
+  {{- end }}
+  - type: aws-cloudwatch
+    metadata:
+      {{- range .Values.ExternalMetric.queries }}
+      namespace: {{ .metricNamespace }}
+      metricName: {{ .metricName }}
+      metricStat: {{ .stat }}
+      metricStatPeriod: {{ .period | quote }}
+      metricUnit: {{ .unit }}
+      {{- $dimensionNameList := list}}
+      {{- $dimensionValueList := list}}
+      {{- range .metricsDimensions }}
+        {{- $dimensionName := .name }}
+        {{- $dimensionValue := .value }}
+        {{- $dimensionNameList = append $dimensionNameList $dimensionName }}
+        {{- $dimensionValueList = append $dimensionValueList $dimensionValue }}
+      {{- end }}
+      dimensionName: {{ (join ";" $dimensionNameList) }}
+      dimensionValue: {{ (join ";" $dimensionValueList) }}
+      minMetricValue: "0"
+      awsRegion: "ap-southeast-1"
+      identityOwner: operator
+      {{- end }}
+      {{- range .Values.hpav2.External }}
+      targetMetricValue: {{ .value | quote }}
+      {{- end }}
+  {{- end }}
+{{- end }}

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -165,3 +165,9 @@ pdb:
 #         app: mongodb-observer # which service you want to match
 #     endpoints:
 #       - port: http # port name of the service expose
+
+# Don’t combine ScaledObject with Horizontal Pod Autoscaler (HPA)
+# exmaple yaml please refer to example/example-keda.yaml
+# KEDA:
+#   ScaledObject:
+#     spec: {}


### PR DESCRIPTION
testing:
```shell
helm3 upgrade example-keda ~/github/helm-charts/simple --namespace default -f example-keda.yaml -i

kubectl describe hpa keda-hpa-example-keda
Name:                                                            keda-hpa-example-keda
Namespace:                                                       default
Labels:                                                          app.kubernetes.io/managed-by=Helm
                                                                 app.kubernetes.io/name=keda-hpa-example-keda
                                                                 app.kubernetes.io/part-of=example-keda
                                                                 app.kubernetes.io/version=2.5.0
                                                                 scaledobject.keda.sh/name=example-keda
Annotations:                                                     <none>
CreationTimestamp:                                               Fri, 07 Jan 2022 17:30:11 +0800
Reference:                                                       Deployment/example-keda
Metrics:                                                         ( current / target )
  "s1-aws-cloudwatch-InstanceId" (target average value):         6 / 60
  "s2-cron-Asia-Taipei-341741x-501741x" (target average value):  1 / 1
  "s3-prometheus-machine_cpu_cores" (target average value):      24 / 100
  resource cpu on pods  (as a percentage of request):            0% (0) / 60%
Min replicas:                                                    1
Max replicas:                                                    10
Deployment pods:                                                 1 current / 1 desired
Conditions:
  Type            Status  Reason              Message
  ----            ------  ------              -------
  AbleToScale     True    ReadyForNewScale    recommended size matches current size
  ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from external metric s1-aws-cloudwatch-InstanceId(&LabelSelector{MatchLabels:map[string]string{scaledobject.keda.sh/name: example-keda,},MatchExpressions:[]LabelSelectorRequirement{},})
  ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
Events:
  Type     Reason                   Age                From                       Message
  ----     ------                   ----               ----                       -------
  Warning  FailedGetResourceMetric  20s (x4 over 66s)  horizontal-pod-autoscaler  failed to get cpu utilization: did not receive metrics for any ready pods
```