### PR TITLE
fix(simple) prevent from setting replica if using KEDA

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {{ .Values.name }}
 spec:
-  {{- if not (or .Values.hpa .Values.hpav2) }}
+  {{- if not (or .Values.hpa .Values.hpav2 ((.Values.KEDA).ScaledObject)) }}
   replicas: {{ .Values.replicaCount }}
   {{- end}}
   strategy:


### PR DESCRIPTION
If we use KEDA, we can skip setting replica in deployment.