### PR TITLE
feat(cronjob): support serviceaccount

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple cronjob template
 name: cronjob
-version: 0.2.0
+version: 0.3.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/cronjob/templates/serviceaccount.yaml
+++ b/cronjob/templates/serviceaccount.yaml
@@ -1,4 +1,10 @@
-{{- if .Values.serviceAccount }}
+{{- if .Values.serviceaccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {{ toYaml .Values.serviceaccount.annotations | nindent 4}}
+  name: {{ .Values.serviceaccount.name | default (printf "%s-pod-service-account" .Values.name) }}
+{{- else if .Values.serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -30,3 +30,10 @@ envFrom: {}
 #   secretRef:
 #     - test-1-secret
 #     - test-2-secret
+
+serviceaccount: {}
+# example
+# serviceaccount:
+#   annotations:
+#     eks.amazonaws.com/role-arn: <aws-role-arn>
+#     name: <serviceaccount-name>


### PR DESCRIPTION
- Allow cronjob chart accept `serviceaccount` (same case as simple chart)
- Allow cronjob chart accept `serviceaccount.name`