### PR TITLE
feature/configmap-checksum

### DIFF
--- a/simple/templates/_compute_checksum.tpl
+++ b/simple/templates/_compute_checksum.tpl
@@ -1,0 +1,8 @@
+{{- define "compute_checksum" -}}
+{{- $subpaths := splitList "/" .path }}
+{{- $data := .Values }}
+{{- range $key, $subpath := $subpaths }}
+{{- $data = index $data $subpath }}
+{{- end }}
+{{- $data | sha256sum }}
+{{- end -}}

--- a/simple/templates/_compute_checksum.tpl
+++ b/simple/templates/_compute_checksum.tpl
@@ -1,8 +1,8 @@
 {{- define "compute_checksum" -}}
-{{- $subpaths := splitList "/" .path }}
-{{- $data := .Values }}
-{{- range $key, $subpath := $subpaths }}
-{{- $data = index $data $subpath }}
-{{- end }}
-{{- $data | sha256sum }}
+  {{- $subpaths := splitList "/" .path }}
+  {{- $data := .Values }}
+  {{- range $key, $subpath := $subpaths }}
+    {{- $data = index $data $subpath }}
+  {{- end }}
+  {{- $data | sha256sum }}
 {{- end -}}

--- a/simple/templates/configmaps.yaml
+++ b/simple/templates/configmaps.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $cm_name }}
+  name: {{ $ref.name | default $cm_name }}
 data:
   {{- range $key, $value := $ref.data }}
   {{ $key | quote }} : {{ $value | quote }}

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -26,12 +26,12 @@ spec:
       {{- if hasKey .Values.deployment "annotations" }}
       annotations:
         {{- range $key, $value := .Values.deployment.annotations }}
-        {{- if hasPrefix "compute_checksum::" $value }}
-        {{- $path := replace "compute_checksum::" "" $value}}
-        {{ $key | quote }} : {{ include "compute_checksum" (dict "path" $path "Values" $.Values) | quote }}
-        {{- else }}
-        {{ $key | quote }} : {{ $value | quote }}
-        {{- end }}
+          {{- if hasPrefix "compute_checksum::" $value }}
+            {{- $path := replace "compute_checksum::" "" $value}}
+              {{- $key | quote | nindent 8 }} : {{ include "compute_checksum" (dict "path" $path "Values" $.Values) | quote }}
+            {{- else }}
+              {{- $key | quote | nindent 8 }} : {{ $value | quote }}
+          {{- end }}
         {{- end }}
       {{- end}}
       labels:

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
         {{- range $key, $value := .Values.deployment.annotations }}
           {{- if hasPrefix "compute_checksum::" $value }}
             {{- $path := replace "compute_checksum::" "" $value}}
-              {{- $key | quote | nindent 8 }} : {{ include "compute_checksum" (dict "path" $path "Values" $.Values) | quote }}
-            {{- else }}
-              {{- $key | quote | nindent 8 }} : {{ $value | quote }}
+            {{- $key | quote | nindent 8 }} : {{ include "compute_checksum" (dict "path" $path "Values" $.Values) | quote }}
+          {{- else }}
+            {{- $key | quote | nindent 8 }} : {{ $value | quote }}
           {{- end }}
         {{- end }}
       {{- end}}

--- a/simple/templates/deployment.yaml
+++ b/simple/templates/deployment.yaml
@@ -26,7 +26,12 @@ spec:
       {{- if hasKey .Values.deployment "annotations" }}
       annotations:
         {{- range $key, $value := .Values.deployment.annotations }}
+        {{- if hasPrefix "compute_checksum::" $value }}
+        {{- $path := replace "compute_checksum::" "" $value}}
+        {{ $key | quote }} : {{ include "compute_checksum" (dict "path" $path "Values" $.Values) | quote }}
+        {{- else }}
         {{ $key | quote }} : {{ $value | quote }}
+        {{- end }}
         {{- end }}
       {{- end}}
       labels:

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -48,6 +48,33 @@ deployment: {}
 #       - name: ndots
 #         value: "2"
 
+# deployment example with configmap volume mount
+# use together with the configmaps example below
+# deployment: 
+#   annotations:
+#     checksum/config.yml: compute_checksum::configmaps/app-config/data/config.yml # compute_checksum will compute the sha256 checksum of the content
+#   containers:
+#     example-app:
+#       name: example-app
+#       image:
+#         repository: example-app
+#         tag: latest
+#       volumes:
+#       - name: app-config-1
+#         subPath: config.yaml
+#         path: /app/config.yaml
+#   volumes:
+#     - name: app-config-1
+#       configMap: {}
+
+# configmaps example
+# configmaps:
+#   app-config:
+#     name: app-config-1
+#     data:
+#       config.yaml: |
+#         test: 1
+
 container:
   image:
     repository: repository_name/image

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -31,6 +31,7 @@ deployment: {}
 # deployment: 
 #   annotations:
 #     checksum/config: checksum
+#     checksum/config.yml: compute_checksum::configmaps/app-config/data/config.yml # `compute_checksum` will compute the sha256 checksum of the content
 #   containers:
 #     example-app:
 #       name: example-app
@@ -43,22 +44,6 @@ deployment: {}
 #         MONGODB_USER:
 #           name: mongodb
 #           key: MONGODB_USER
-#   dnsConfig:
-#     options:
-#       - name: ndots
-#         value: "2"
-
-# deployment example with configmap volume mount
-# use together with the configmaps example below
-# deployment: 
-#   annotations:
-#     checksum/config.yml: compute_checksum::configmaps/app-config/data/config.yml # compute_checksum will compute the sha256 checksum of the content
-#   containers:
-#     example-app:
-#       name: example-app
-#       image:
-#         repository: example-app
-#         tag: latest
 #       volumes:
 #       - name: app-config-1
 #         subPath: config.yaml
@@ -66,6 +51,10 @@ deployment: {}
 #   volumes:
 #     - name: app-config-1
 #       configMap: {}
+#   dnsConfig:
+#     options:
+#       - name: ndots
+#         value: "2"
 
 # configmaps example
 # configmaps:


### PR DESCRIPTION
## Use case:
When the content of a configmap (mounted as volume) is change, helm / k8s will not automatically re-deploy the pods.

Adding a checksum to the `annotations` part makes helm / k8s detect the change.

This PR enables the capability to place SHA256 checksum on deployment annotations section by specifying the property path of a value.

## Sample usage:

helm value:

```
deployment:
  annotations:
    checksum/config.yaml: compute_checksum::configmaps/config/data/config.yaml

configmaps:
  config:
    name: config-1
    data:
      config.yaml: |
        test: 1
```

output:
```
apiVersion: apps/v1
kind: Deployment
...
spec:
  template:
    metadata:
      annotations:
        "checksum/config.yaml" : "c27928eca92fa47099507f402b4f48f298f84fdb22d0525a4020f0a13e08f2e3"
...
```

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: config-1
data:
  "config.yaml" : "test: 1\n"
```
