### PR TITLE
feat(ingress): update api version

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.6.0
+version: 0.10.1
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.10.1
+version: 0.7.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/_ingress_multiple.tpl
+++ b/simple/templates/_ingress_multiple.tpl
@@ -30,7 +30,11 @@ spec:
             service:
               name: {{ .backend.serviceName }}
               port: 
+              {{- if regexMatch "^[1-9][0-9]+$" (toString .backend.servicePort) }}
                 number: {{ .backend.servicePort }}
+              {{- else }}
+                name: {{ .backend.servicePort }}
+              {{- end }}
           path: {{ .path | default "/*" }}
           pathType: {{ .pathType | default "ImplementationSpecific" }}
         {{- end }}

--- a/simple/templates/_ingress_multiple.tpl
+++ b/simple/templates/_ingress_multiple.tpl
@@ -2,7 +2,7 @@
 {{- if eq .Values.EnableMutilpleIngress true }}
 {{- range $ingress_name, $ref := .Values.ingress }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $ingress_name }}
@@ -27,9 +27,12 @@ spec:
         paths:
         {{- range .http.paths }}
         - backend:
-            serviceName: {{ .backend.serviceName }}
-            servicePort: {{ .backend.servicePort }}
-          path: {{ .path | default "/*"}}
+            service:
+              name: {{ .backend.serviceName }}
+              port: 
+                number: {{ .backend.servicePort }}
+          path: {{ .path | default "/*" }}
+          pathType: {{ .pathType | default "ImplementationSpecific" }}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/simple/templates/_ingress_single.tpl
+++ b/simple/templates/_ingress_single.tpl
@@ -1,5 +1,5 @@
 {{- define "ingress.ingress_single" -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .Values.name }}
@@ -24,9 +24,12 @@ spec:
         paths:
         {{- range .http.paths }}
         - backend:
-            serviceName: {{ .backend.serviceName }}
-            servicePort: {{ .backend.servicePort }}
-          path: {{ .path | default "/*"}}
+            service:
+              name: {{ .backend.serviceName }}
+              port: 
+                number: {{ .backend.servicePort }}
+          path: {{ .path | default "/*" }}
+          pathType: {{ .pathType | default "ImplementationSpecific" }}
         {{- end }}
     {{- end }}
 {{- end -}}

--- a/simple/templates/_ingress_single.tpl
+++ b/simple/templates/_ingress_single.tpl
@@ -27,7 +27,11 @@ spec:
             service:
               name: {{ .backend.serviceName }}
               port: 
+              {{- if regexMatch "^[1-9][0-9]+$" (toString .backend.servicePort) }}
                 number: {{ .backend.servicePort }}
+              {{- else }}
+                name: {{ .backend.servicePort }}
+              {{- end }}
           path: {{ .path | default "/*" }}
           pathType: {{ .pathType | default "ImplementationSpecific" }}
         {{- end }}

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -86,6 +86,7 @@ EnableMutilpleIngress: false
 #              serviceName: example
 #              servicePort: 80
 #            path: /health_check
+#            pathType: ImplementationSpecific
 #  external-ingress:
 #    annotations:
 #      kubernetes.io/ingress.class: alb
@@ -97,6 +98,7 @@ EnableMutilpleIngress: false
 #              serviceName: example
 #              servicePort: 80
 #            path: /health_check
+#            pathType: ImplementationSpecific
 
 # for single service
 # service:


### PR DESCRIPTION
### Ingress
The **extensions/v1beta1** and **networking.k8s.io/v1beta1** API versions of Ingress is no longer served as of v1.22.

- Migrate manifests and API clients to use the **networking.k8s.io/v1** API version, available since v1.19.
- All existing persisted objects are accessible via the new API
- Notable changes:
  - `spec.backend` is renamed to `spec.defaultBackend`
  - The backend `serviceName` field is renamed to `service.name`
  - Numeric backend `servicePort` fields are renamed to `service.port.number`
  - String backend `servicePort` fields are renamed to `service.port.name`
  - `pathType` is now required for each specified path. Options are `Prefix`, `Exact`, and `ImplementationSpecific`. To match the undefined `v1beta1` behavior, use `ImplementationSpecific`.
reference: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
