### PR TITLE
deprecate old rbac api

### DIFF
--- a/eks/Chart.yaml
+++ b/eks/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart to init eks and add role policy
 name: eks
-version: 0.0.1
+version: 0.1.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/eks/templates/role_admin.yaml
+++ b/eks/templates/role_admin.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.enableDefaultRole }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-{{ .Release.Namespace }}-admin
   namespace: {{ .Release.Namespace }}
@@ -10,7 +10,7 @@ rules:
     verbs: ["*"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-binding-{{ .Release.Namespace }}-admin
   namespace: {{ .Release.Namespace }}

--- a/eks/templates/role_custom.yaml
+++ b/eks/templates/role_custom.yaml
@@ -6,7 +6,7 @@
 {{- range .Values.customRole }}
 
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-{{ $projectName }}-{{ .name }}
   namespace: {{ $namespace }}
@@ -27,7 +27,7 @@ rules:
 {{- end }}
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-binding-{{ $projectName }}-{{ .name }}
   namespace: {{ $namespace }}

--- a/eks/templates/role_po.yaml
+++ b/eks/templates/role_po.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.enableDefaultRole }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-{{ .Release.Namespace }}-po
   namespace: {{ .Release.Namespace }}
@@ -13,7 +13,7 @@ rules:
     verbs: ["create"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-binding-{{ .Release.Namespace }}-po
   namespace: {{ .Release.Namespace }}

--- a/eks/templates/role_read_only.yaml
+++ b/eks/templates/role_read_only.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.enableDefaultRole }}
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-{{ .Release.Namespace }}-read-only
   namespace: {{ .Release.Namespace }}
@@ -10,7 +10,7 @@ rules:
     verbs: ["get", "watch", "list"]
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: role-binding-{{ .Release.Namespace }}-read-only
   namespace: {{ .Release.Namespace }}

--- a/fluentd-cloudwatch/Chart.yaml
+++ b/fluentd-cloudwatch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart to add fluentd daemonset and send logs to cloudwatch
 name: fluentd-cloudwatch
-version: 0.0.1
+version: 0.1.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/fluentd-cloudwatch/templates/service_account.yaml
+++ b/fluentd-cloudwatch/templates/service_account.yaml
@@ -4,7 +4,7 @@ metadata:
   name: fluentd
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: fluentd
@@ -16,7 +16,7 @@ rules:
   - pods
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: fluentd


### PR DESCRIPTION
The **rbac.authorization.k8s.io/v1beta1** API version of ClusterRole, ClusterRoleBinding, Role, and RoleBinding is no longer served as of v1.22.

* Migrate manifests and API clients to use the **rbac.authorization.k8s.io/v1** API version, available since v1.8.
* All existing persisted objects are accessible via the new APIs
* No notable changes
