### PR TITLE
Update pdb api version

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.15.0
+version: 0.16.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/pdb.yaml
+++ b/simple/templates/pdb.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.pdb }}
 {{- if eq .Values.pdb.enable true }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ .Values.name }}


### PR DESCRIPTION
1. `policy/v1beta1` for PodDisruptionBudget is no longer served as of v1.25[1].
2. `policy/v1` is supported since v1.21.

Differenece between `policy/v1` and `policy/v1beta` [2]:
```
Note: The behavior for an empty selector differs between the policy/v1beta1 and policy/v1 APIs for PodDisruptionBudgets. For policy/v1beta1 an empty selector matches zero pods, while for policy/v1 an empty selector matches every pod in the namespace.
```

As we do not have empty selector, we can just update to v1.

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125
[2] https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget