### PR TITLE
feature/add backburner annotation

### DIFF
--- a/backburner/Chart.yaml
+++ b/backburner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Helm chart for ruby backburner workers
 name: backburner
-version: 0.4.0
+version: 0.5.0
 appVersion: 0.0.1

--- a/backburner/templates/deployment.yaml
+++ b/backburner/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       app: {{ $.Values.name }}-{{ $resourceName }}
   template:
     metadata:
+      {{- if .annotations }}
+      annotations:
+        {{- toYaml .annotations | nindent 8 }}
+      {{- end }}
       labels:
         app: {{ $.Values.name }}-{{ $resourceName }}
     spec:

--- a/backburner/templates/hpa.yaml
+++ b/backburner/templates/hpa.yaml
@@ -3,7 +3,7 @@
   {{- if (default .standAlone false ) }}
     {{ fail "Don't create HPA at standalone mode." }}
   {{- end }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ $.Values.name }}-{{ .name }}

--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple cronjob template
 name: cronjob
-version: 0.4.2
+version: 0.5.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/cronjob/templates/cronjob.yaml
+++ b/cronjob/templates/cronjob.yaml
@@ -4,7 +4,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 {{- else }}
 # The "apiVersion" and "kind" for "k8s cron job"
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 {{- end }}
 metadata:

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.16.0
+version: 0.17.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/hpa.yaml
+++ b/simple/templates/hpa.yaml
@@ -18,7 +18,7 @@ spec:
   targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
 {{- else if .Values.hpav2 }}
   {{- if (empty .Values.hpav2.External) }}
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.name }}


### PR DESCRIPTION
1. Add Backburner chart worker annotation field
2. Modify some apiVersion for new k8s version
  a. cronjob `batch/v1beta1` -> `batch/v1` [1]
  b. hpa `autoscaling/v2beta2` -> `autoscaling/v2` [2]

[1] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125
[2] https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126