### PR TITLE
feat(cronjob): add pdb template and values

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple cronjob template
 name: cronjob
-version: 0.6.2
+version: 0.6.3
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/cronjob/templates/pdb.yaml
+++ b/cronjob/templates/pdb.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.pdb }}
+{{- if eq .Values.pdb.enable true }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Values.name }}
+spec:
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable | default "100%" }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+{{- end }}
+{{- end }}

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -149,3 +149,10 @@ serviceaccount: {}
 
 # This can be used to suspend the cron workflow by default, set this to true to suspend the cron workflow by default
 suspend: false
+
+pdb:
+  # If you just set "enable: true", default will set to "minAvailable: 100%" unless you have set other parameters.
+  enable: false
+  # Note: You can specify only one of maxUnavailable and minAvailable in a single PodDisruptionBudget, and if you setting both will only set maxUnavailable.
+  # minAvailable: 50%
+  # maxUnavailable: 50%


### PR DESCRIPTION
Aimed to add pdb to tackle argo cronworkflow pods scheduled right before karpenter decides to delete a node, which does not respect the karpenter's do-no-evict annotation