### PR TITLE
cronjob: use curl from private registry instead of docker.io

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple cronjob template
 name: cronjob
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/cronjob/templates/_exit_handler_healthcheck_io.tpl
+++ b/cronjob/templates/_exit_handler_healthcheck_io.tpl
@@ -2,13 +2,13 @@
 {{- $healthcheckIo := .Values.exitNotifications.healthcheckIo | default dict -}}
       - name: notice-healthcheck-io-succeeded # For cronjob health check, as the schedule may different therefore each cronjob will have different uuid
         container:
-          image: curlimages/curl
+          image: 332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/curlimages/curl:8.4.0
           command: [ "sh", "-c" ]
           args:
             - curl https://hc-ping.com/{{ required "exitNotifications.healthcheckIo.uuid must be provided" $healthcheckIo.uuid }}
       - name: notice-healthcheck-io-failed
         container:
-          image: curlimages/curl
+          image: 332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/curlimages/curl:8.4.0
           command: [ "sh", "-c" ]
           args:
             - curl https://hc-ping.com/{{ required "exitNotifications.healthcheckIo.uuid must be provided" $healthcheckIo.uuid }}/fail

--- a/cronjob/templates/_exit_handler_slack_app.tpl
+++ b/cronjob/templates/_exit_handler_slack_app.tpl
@@ -2,7 +2,7 @@
 {{- $slackApp := .Values.exitNotifications.slackApp | default dict -}}
       - name: notice-slack-app-succeeded
         container:
-          image: curlimages/curl
+          image: 332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/curlimages/curl:8.4.0
           command: [sh, -c]
           args: [
             "curl -X POST -H 'Content-type: application/json' --data '{\"attachments\": [
@@ -72,7 +72,7 @@
           ]
       - name: notice-slack-app-failed
         container:
-          image: curlimages/curl
+          image: 332947256684.dkr.ecr.ap-southeast-1.amazonaws.com/curlimages/curl:8.4.0
           command: [sh, -c]
           args: [
             "curl -X POST -H 'Content-type: application/json' --data '{\"attachments\": [


### PR DESCRIPTION
1. 2023/11/12 UTC+8 dockerhub down
2. we might encounter dockerhub ratelimit
so change the registry to private one.