### PR TITLE
feat: container add support for startupProbe

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.17.1
+version: 0.17.2
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/_container.tpl
+++ b/simple/templates/_container.tpl
@@ -48,6 +48,9 @@
         {{- if hasKey . "readinessProbe" }}
         readinessProbe: {{- toYaml .readinessProbe | nindent 10 }}
         {{- end }}
+        {{- if hasKey . "startupProbe" }}
+        startupProbe: {{- toYaml .startupProbe | nindent 10 }}
+        {{- end }}
         {{- if hasKey . "volumes" }}
         volumeMounts:
           {{- range $key, $vol := $.volumes }}


### PR DESCRIPTION
Add support for startupProbe to facilitate protecting slow start containers 
ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes