### PR TITLE
Allow to skip creating serviceaccount

### DIFF
--- a/cronjob/templates/serviceaccount.yaml
+++ b/cronjob/templates/serviceaccount.yaml
@@ -1,9 +1,15 @@
 {{- if .Values.serviceaccount }}
+{{- if .Values.serviceaccount.skipCreation }}
+{{- /*
+Skip create service account
+*/}}
+{{- else}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations: {{ toYaml .Values.serviceaccount.annotations | nindent 4}}
   name: {{ .Values.serviceaccount.name | default (printf "%s-pod-service-account" .Values.name) }}
+{{- end}}
 {{- else if .Values.serviceAccount }}
 apiVersion: v1
 kind: ServiceAccount

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -140,12 +140,14 @@ envFrom: {}
 #     - test-2-secret
 
 # Service account is used by pod. For more details on fields "serviceaccount" and "serviceAccount", please have a look on ./cronjob/templates/serviceaccount.yaml 
+# "serviceAccount" is deprecated, please use "serviceaccount" instead.
 serviceaccount: {}
 # example
 # serviceaccount:
 #   annotations:
 #     eks.amazonaws.com/role-arn: <aws-role-arn>
 #     name: <serviceaccount-name>
+#     skipCreation: false
 
 # This can be used to suspend the cron workflow by default, set this to true to suspend the cron workflow by default
 suspend: false

--- a/simple/templates/serviceaccount.yaml
+++ b/simple/templates/serviceaccount.yaml
@@ -1,7 +1,13 @@
 {{- if .Values.serviceaccount }}
+{{- if .Values.serviceaccount.skipCreation }}
+{{- /*
+Skip create service account
+*/}}
+{{- else}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations: {{ toYaml .Values.serviceaccount.annotations | nindent 4}}
   name: {{ .Values.serviceaccount.name | default (printf "%s-pod-service-account" .Values.name) }}
+{{- end}}
 {{- end}}

--- a/simple/values.yaml
+++ b/simple/values.yaml
@@ -337,3 +337,12 @@ analyses: {}
 #               sum(irate(
 #                 istio_requests_total{reporter="source",destination_service=~"{{args.service-name}}"}[5m]
 #               ))
+
+# Service account is used by pod. For more details on fields "serviceaccount", please have a look on ./simple/templates/serviceaccount.yaml 
+serviceaccount: {}
+# example
+# serviceaccount:
+#   annotations:
+#     eks.amazonaws.com/role-arn: <aws-role-arn>
+#   name: <serviceaccount-name>
+#   skipCreation: false


### PR DESCRIPTION
Sometime we need to reuse created service account for deployment or cronjob, add `.Value.serviceaccount.skipCreation` to control whether service account should be created.