### PR TITLE
feat(deployment): support downward api

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.20.0
+version: 0.20.1
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/_container.tpl
+++ b/simple/templates/_container.tpl
@@ -25,6 +25,12 @@
               name: {{ $ref.name }}
               key: {{ $ref.key | quote }}
         {{- end }}
+        {{- range .envFromFieldRefs }}
+        - name: {{ .name }}
+          valueFrom:
+            fieldRef:
+              fieldPath: {{ .fieldPath }}
+        {{- end }}
         envFrom:
         {{- range .envFromConfigmap }}
         - configMapRef:


### PR DESCRIPTION
support downward api in deployment
reference: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

how to user

example:
```
  containers:
    mongodb-sink-connector:
      envFromFieldRefs:
        - name: CONNECT_REST_ADVERTISED_HOST_NAME
          fieldPath: status.podIP
```

output:
```
      containers:
      - name: mongodb-sink-connector
        image: "xxxxxx"
        env:
        - name: CONNECT_REST_ADVERTISED_HOST_NAME
          valueFrom:
            fieldRef:
              fieldPath: status.podIP
```