### PR TITLE
 fix: adding alb businessid if original tags doesnt contain businessid tag

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.21.1
+version: 0.21.2
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/_ingress_single.tpl
+++ b/simple/templates/_ingress_single.tpl
@@ -9,13 +9,22 @@ metadata:
     {{ $key }}: {{ $value }}
     {{- end }}
   annotations:
-{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- $omittedAnnotations := omit .Values.ingress.annotations "alb.ingress.kubernetes.io/tags" }}
+{{ toYaml $omittedAnnotations | indent 4 }}    
     {{- if and (not (index .Values.ingress.annotations "alb.ingress.kubernetes.io/ssl-policy")) (index .Values.ingress.annotations "alb.ingress.kubernetes.io/load-balancer-name") (index .Values.ingress.annotations "alb.ingress.kubernetes.io/certificate-arn") }}
     alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS13-1-2-2021-06"
     {{- end }}
     {{- if eq (index .Values.ingress.annotations "kubernetes.io/ingress.class") "alb" }}
     {{- if not (index .Values.ingress.annotations "alb.ingress.kubernetes.io/tags") }}
     alb.ingress.kubernetes.io/tags: {{ printf "businessid=%s" .Values.businessid | quote }}
+    {{- else }}
+    {{- $tags := index .Values.ingress.annotations "alb.ingress.kubernetes.io/tags" }}
+    {{- if not (regexMatch "businessid=[^,]+" $tags) }}
+    {{- $newTags := printf "%s,businessid=%s" $tags .Values.businessid | quote }}
+    alb.ingress.kubernetes.io/tags: {{ $newTags }}
+    {{- else }}
+    alb.ingress.kubernetes.io/tags: {{ $tags }}
+    {{- end }}  
     {{- end }}
     {{- end }}
 spec:

--- a/simple/tests/ingress_test.yaml
+++ b/simple/tests/ingress_test.yaml
@@ -35,6 +35,21 @@ tests:
           content:
             kubernetes.io/ingress.class: alb
             alb.ingress.kubernetes.io/tags: businessid=00456
+  
+  - it: should keep original alb.ingress.kubernetes.io/tags from values for multiple ingresses
+    values:
+      - ./values/simple/ingress_alb_multiple.yaml
+    set:
+      ingress:
+        nginx:
+          annotations:
+            alb.ingress.kubernetes.io/tags: businessid=00456
+    asserts:
+    - isSubset:
+        path: metadata.annotations
+        content:
+          alb.ingress.kubernetes.io/tags: businessid=00456
+          kubernetes.io/ingress.class: alb
 
   - it: should not render alb with a cost tag annotation
     values:
@@ -45,3 +60,32 @@ tests:
           content:
             kubernetes.io/ingress.class: alb
             alb.ingress.kubernetes.io/tags: businessid=00123
+
+  - it: should append businessid tag annotation when other tags exist
+    values:
+      - ./values/simple/ingress_alb.yaml
+    set:
+      ingress:
+        annotations:
+          alb.ingress.kubernetes.io/tags: Environment=production
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            kubernetes.io/ingress.class: alb
+            alb.ingress.kubernetes.io/tags: Environment=production,businessid=00123
+
+  - it: should append businessid tag annotation when other tags exist for multiple ingresses
+    values:
+      - ./values/simple/ingress_alb_multiple.yaml
+    set:
+      ingress:
+        nginx:
+          annotations:
+            alb.ingress.kubernetes.io/tags: Environment=production
+    asserts:
+    - isSubset:
+        path: metadata.annotations
+        content:
+          alb.ingress.kubernetes.io/tags: Environment=production,businessid=00123
+          kubernetes.io/ingress.class: alb


### PR DESCRIPTION
```
 helm unittest simple

### Chart [ simple ] simple

 PASS  Ingress Test	simple/tests/ingress_test.yaml

Charts:      1 passed, 1 total
Test Suites: 1 passed, 1 total
Tests:       7 passed, 7 total
Snapshot:    0 passed, 0 total
Time:        44.249208ms
```

Few testing result from multiple ingress:

1.  appending businessid on the tag annotations:
```
+     alb.ingress.kubernetes.io/tags: "Environment=production,ManagedBy=Terraform,ProjectName=Cst Menu Hidden,TeamName=CST,IngressName=api,businessid=00123"
```

2. already existing businessid on the tag annotaions:
```
alb.ingress.kubernetes.io/tags: Environment=production,ManagedBy=Terraform,ProjectName=Cst Menu Hidden,TeamName=CST,IngressName=api,businessid=00123
```

3. not having tag annotations at all:
```
+     alb.ingress.kubernetes.io/tags: "businessid=00123"
```
