### PR TITLE
feat: update default preStop hook sleep from 15s to 60s

### DIFF
--- a/cronjob/Chart.yaml
+++ b/cronjob/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple cronjob template
 name: cronjob
-version: 1.0.1
+version: 1.0.2
 appVersion: 1.0.0
 tillerVersion: ">=2.14.3"

--- a/cronjob/templates/_k8s_cronjob.tpl
+++ b/cronjob/templates/_k8s_cronjob.tpl
@@ -5,7 +5,9 @@
         cronjob_name: {{ .Values.name }}
     spec:
       backoffLimit: {{ .Values.job.retries }}
-      activeDeadlineSeconds: {{ .Values.job.timeout }}
+      {{- with .Values.job.timeout }}
+      activeDeadlineSeconds: {{ . }}
+      {{- end }}
       template:
         metadata:
           annotations:

--- a/cronjob/values.yaml
+++ b/cronjob/values.yaml
@@ -24,8 +24,9 @@ job:
   # Number of retries if error occurred
   retries: 1
 
-  # Active Deadline Seconds of the pod. If you you are using argo cron workflow, you can use -1 to disable active Deadline Seconds
-  timeout: 1800
+  # Active Deadline Seconds of the pod.
+  # example
+  # timeout: 1800
 
   # Jobs History Limit of cron job. For "success", it will assign to spec.successfulJobsHistoryLimit. It is optional and having default value 3. For "failed", it will assign to spec.failedJobsHistoryLimit. It is optional and having default value 1
   history: {}

--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.22.0
+version: 0.23.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/_container.tpl
+++ b/simple/templates/_container.tpl
@@ -77,6 +77,6 @@
         lifecycle:
           preStop:
             exec:
-              command: ["sleep", "15"]
+              command: ["sleep", "60"]
         {{- end }}
 {{- end -}}

--- a/simple/templates/_container_legacy.tpl
+++ b/simple/templates/_container_legacy.tpl
@@ -56,6 +56,6 @@
         lifecycle:
           preStop:
             exec:
-              command: ["sleep", "15"]
+              command: ["sleep", "60"]
         {{- end }}
 {{- end -}}


### PR DESCRIPTION
To avoid HTTP 502 error during AWS LB controller performing the `DeregisterTargets` API. 