### PR TITLE
feat: update default preStop hook sleep from 15s to 60s

### DIFF
--- a/simple/Chart.yaml
+++ b/simple/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 description: Helm chart with simple deployment/service template
 name: simple
-version: 0.22.0
+version: 0.23.0
 appVersion: 0.0.1
 tillerVersion: ">=2.14.3"

--- a/simple/templates/_container.tpl
+++ b/simple/templates/_container.tpl
@@ -77,6 +77,6 @@
         lifecycle:
           preStop:
             exec:
-              command: ["sleep", "15"]
+              command: ["sleep", "60"]
         {{- end }}
 {{- end -}}

--- a/simple/templates/_container_legacy.tpl
+++ b/simple/templates/_container_legacy.tpl
@@ -56,6 +56,6 @@
         lifecycle:
           preStop:
             exec:
-              command: ["sleep", "15"]
+              command: ["sleep", "60"]
         {{- end }}
 {{- end -}}


### PR DESCRIPTION
* To avoid HTTP 502 error during AWS LB controller performing the `DeregisterTargets` API.