### PR TITLE
feat(backburner): add support for garbage limit

### DIFF
--- a/backburner/Chart.yaml
+++ b/backburner/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: Helm chart for ruby backburner workers
 name: backburner
-version: 0.6.0
+version: 0.7.0
 appVersion: 0.0.1

--- a/backburner/templates/_container.tpl
+++ b/backburner/templates/_container.tpl
@@ -23,6 +23,7 @@
           {{- range $i, $items := .queue }}
             {{- $queueName := get $items "queueName" }}
             {{- $listener := get $items "listener" | int }}
+            {{- $garbage := get $items "garbage" | default "" }}
             {{- if (default $standAlone false ) }}
               {{- if gt $listener 1 }} 
               {{ fail "listener more than one failed when the standalone mode."}}
@@ -33,11 +34,11 @@
                 {{- $listener = 2 }}
               {{- end}}
             {{- end}}
-            {{- $tmpItem := printf "%v:%v" $queueName $listener }}
+            {{- $tmpItem := printf "%v:%v:%v" $queueName $listener $garbage }}
             {{- $queueList = append $queueList $tmpItem }}
           {{- end }}
-          {{- $queueName := (join "," $queueList) }}
-          - bundle exec backburner -e $RAILS_ENV -q {{ $queueName }}
+          {{- $queueName := printf "\"%s\"" (join "," $queueList) }}
+          - QUEUE={{ $queueName }} RAILS_ENV=$RAILS_ENV bundle exec rake backburner:threads_on_fork:work
         {{- end }}
         image: "{{ .image.repository }}:{{ .image.tag }}"
         imagePullPolicy: "IfNotPresent"

--- a/backburner/values.yaml
+++ b/backburner/values.yaml
@@ -36,6 +36,7 @@ workers: []
 #   queue:
 #     - queueName: custom-jobs
 #       listener: 2
+#       garbage: 100 # Number of job executions before garbage collection, note that this only works on ThreadsOnFork worker
 #   resources:
 #     limits:
 #       cpu: "300m"
@@ -56,8 +57,8 @@ workers: []
 #         percent: 70
 # - name: worker1
 #   queue:
-#     - queueName: user-import-notification0 # default listener: 2
-#     - queueName: user-import-notification1 # default listener: 2
+#     - queueName: user-import-notification0 # default listener: 2, default garbage: ""
+#     - queueName: user-import-notification1 # default listener: 2, default garbage: ""
 #   resources:
 #     limits:
 #       cpu: "2"
@@ -67,8 +68,8 @@ workers: []
 #       memory: "4Gi"
 # - name: worker2
 #   queue:
-#     - queueName: user-import-notification0 # default listener: 2
-#     - queueName: user-import-notification1 # default listener: 2
+#     - queueName: user-import-notification0 # default listener: 2, default garbage: ""
+#     - queueName: user-import-notification1 # default listener: 2, default garbage: ""
 #   resources:
 #     limits:
 #       cpu: "2"

--- a/backburner/values.yaml
+++ b/backburner/values.yaml
@@ -57,8 +57,8 @@ workers: []
 #         percent: 70
 # - name: worker1
 #   queue:
-#     - queueName: user-import-notification0 # default listener: 2, default garbage: ""
-#     - queueName: user-import-notification1 # default listener: 2, default garbage: ""
+#     - queueName: user-import-notification0 # default listener: 2, garbage: ""
+#     - queueName: user-import-notification1 # default listener: 2, garbage: ""
 #   resources:
 #     limits:
 #       cpu: "2"
@@ -68,8 +68,8 @@ workers: []
 #       memory: "4Gi"
 # - name: worker2
 #   queue:
-#     - queueName: user-import-notification0 # default listener: 2, default garbage: ""
-#     - queueName: user-import-notification1 # default listener: 2, default garbage: ""
+#     - queueName: user-import-notification0 # default listener: 2, garbage: ""
+#     - queueName: user-import-notification1 # default listener: 2, garbage: ""
 #   resources:
 #     limits:
 #       cpu: "2"


### PR DESCRIPTION
- Added parameter `garbage` to support configuring GC per forked worker
- Updated to use rake task instead of cli to run backburner to support configuring GC globally using environment variables 